### PR TITLE
feat: hide prev/next buttons if there are no episodes

### DIFF
--- a/app-mobile/src/main/java/ru/radiationx/anilibria/ui/activities/MyPlayerActivity.kt
+++ b/app-mobile/src/main/java/ru/radiationx/anilibria/ui/activities/MyPlayerActivity.kt
@@ -305,8 +305,8 @@ class MyPlayerActivity : BaseActivity() {
             setOpeningListener(alibControlListener)
             setVisibilityListener(ControlsVisibilityListener())
             let {
-                it.setNextButtonRemoved(false)
-                it.setPreviousButtonRemoved(false)
+                it.setNextButtonRemoved(currentEpisodeId == releaseData.episodes.last().id)
+                it.setPreviousButtonRemoved(currentEpisodeId == releaseData.episodes.first().id)
                 it.setButtonListener(controlsListener)
             }
         }


### PR DESCRIPTION
Hi there. @RadiationX 
I've got a noisy issue. 
Every time I've been watching serise I don't know whether it contains next episode or not

I've added a fix in initial player activity