### PR TITLE
Автопроск опенингов для тв

### DIFF
--- a/app-tv/src/main/java/ru/radiationx/anilibria/screen/player/BasePlayerFragment.kt
+++ b/app-tv/src/main/java/ru/radiationx/anilibria/screen/player/BasePlayerFragment.kt
@@ -11,6 +11,7 @@ import androidx.leanback.app.VideoSupportFragmentGlueHost
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.ClassPresenterSelector
 import androidx.leanback.widget.ListRow
+import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
@@ -18,7 +19,9 @@ import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.ui.leanback.LeanbackPlayerAdapter
+import ru.radiationx.anilibria.R
 import ru.radiationx.anilibria.ui.presenter.cust.CustomListRowPresenter
+import ru.radiationx.data.datasource.holders.PreferencesHolder
 import ru.radiationx.data.player.PlayerDataSourceProvider
 import ru.radiationx.quill.get
 
@@ -44,6 +47,9 @@ open class BasePlayerFragment : VideoSupportFragment() {
 
         skipsPart = PlayerSkipsPart(
             parent = view as FrameLayout,
+            skipButtonText = getString(R.string.player_skip),
+            coroutineScope = viewLifecycleOwner.lifecycleScope,
+            playerSkipsTimer = get<PreferencesHolder>().playerSkipsTimer,
             onSeek = {
                 player?.seekTo(it)
             },

--- a/app-tv/src/main/res/layout/view_player_skips.xml
+++ b/app-tv/src/main/res/layout/view_player_skips.xml
@@ -13,7 +13,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
-        android:text="Пропустить" />
+        android:text="@string/player_skip" />
 
     <Button
         android:id="@+id/btSkipsCancel"

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="global_search_hint">Поиск аниме</string>
     <string name="global_search_label">AniLibria TV</string>
     <string name="global_search_settings_description">Аниме на AniLibria TV</string>
+
+    <string name="player_skip">Пропустить</string>
 </resources>


### PR DESCRIPTION
Добавил автопропуск опенингов для тв версии.

По умолчанию автопропуск включен, т.к. это значение по умолчанию для playerSkipsTimer из PreferencesStorage.
Если пользователь нажмет на "смотреть" во время проигрывания опенинга, то автопропуск отключается до тех пор, пока пользователь не выберет "пропустить" в следующий раз.

Демонстрация:
https://youtu.be/q4rMu4-dxVY