### PR TITLE
fix(tv/player): корректное скрытие оверлея и skip‑логики + feat(tv/ui): прокручиваемое описание релиза

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # AniLibria
+
+<!-- public-repo-status -->
+> Status: Public source fork. Downloads and user support stay with the upstream official channels; this fork does not publish Android builds through GitHub Releases.
+
 Клиент для сайта [AniLibria.tv](https://anilibria.tv/)
 
-Мобильное приложение: [RuStore](https://www.rustore.ru/catalog/app/ru.radiationx.anilibria.app) | [Releases](https://github.com/anilibria/anilibria-app/releases?q=version)
+Мобильное приложение: [RuStore](https://www.rustore.ru/catalog/app/ru.radiationx.anilibria.app)
 
-Android TV приложение: [RuStore](https://www.rustore.ru/catalog/app/ru.radiationx.anilibria.app.tv) | [Releases](https://github.com/anilibria/anilibria-app/releases?q=tv)
+Android TV приложение: [RuStore](https://www.rustore.ru/catalog/app/ru.radiationx.anilibria.app.tv)
 
 # Лицензия #
 Исходный код распостраняется под лицензией GPL v3

--- a/app-tv/src/main/java/ru/radiationx/anilibria/screen/details/DetailFragment.kt
+++ b/app-tv/src/main/java/ru/radiationx/anilibria/screen/details/DetailFragment.kt
@@ -6,9 +6,9 @@ import androidx.core.graphics.ColorUtils
 import androidx.leanback.app.RowsSupportFragment
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.ClassPresenterSelector
+import androidx.leanback.widget.HeaderItem
 import androidx.leanback.widget.ListRow
 import androidx.leanback.widget.Row
-import androidx.lifecycle.ViewModel
 import ru.radiationx.anilibria.common.BaseCardsViewModel
 import ru.radiationx.anilibria.common.GradientBackgroundManager
 import ru.radiationx.anilibria.common.LibriaCard
@@ -23,16 +23,20 @@ import ru.radiationx.anilibria.ui.presenter.cust.CustomListRowPresenter
 import ru.radiationx.anilibria.ui.presenter.cust.CustomListRowViewHolder
 import ru.radiationx.data.entity.domain.types.ReleaseId
 import ru.radiationx.quill.QuillExtra
-import ru.radiationx.quill.inject
 import ru.radiationx.quill.viewModel
 import ru.radiationx.shared.ktx.android.getExtraNotNull
 import ru.radiationx.shared.ktx.android.putExtra
 import ru.radiationx.shared.ktx.android.subscribeTo
 
 data class DetailExtra(
-    val id: ReleaseId,
+    val id: ReleaseId
 ) : QuillExtra
 
+/**
+ * Фрагмент, показывающий:
+ *  1) «Шапку» (ReleaseDetails)
+ *  2) «Related»/«Recommends» списки карточек
+ */
 class DetailFragment : RowsSupportFragment() {
 
     companion object {
@@ -43,37 +47,43 @@ class DetailFragment : RowsSupportFragment() {
         }
     }
 
-    private val backgroundManager by inject<GradientBackgroundManager>()
+    private val backgroundManager by lazy { GradientBackgroundManager(requireActivity()) }
 
+    /** Аргументы */
     private val argExtra by lazy {
         DetailExtra(id = getExtraNotNull(ARG_ID))
     }
 
+    /** Презентеры для строк/рядов */
     private val rowsPresenter by lazy {
         ClassPresenterSelector().apply {
+            // Для обычного ListRow
             addClassPresenter(ListRow::class.java, CustomListRowPresenter())
+            // Для детали (LibriaDetailsRow)
             addClassPresenter(
-                LibriaDetailsRow::class.java, ReleaseDetailsPresenter(
-                    continueClickListener = headerViewModel::onContinueClick,
-                    playClickListener = headerViewModel::onPlayClick,
-                    favoriteClickListener = headerViewModel::onFavoriteClick,
-                    descriptionClickListener = headerViewModel::onDescriptionClick,
-                    otherClickListener = headerViewModel::onOtherClick
+                LibriaDetailsRow::class.java,
+                ReleaseDetailsPresenter(
+                    continueClickListener = { headerViewModel.onContinueClick() },
+                    playClickListener = { headerViewModel.onPlayClick() },
+                    favoriteClickListener = { headerViewModel.onFavoriteClick() },
+                    descriptionClickListener = { headerViewModel.onDescriptionClick() },
+                    otherClickListener = { headerViewModel.onOtherClick() }
                 )
             )
         }
     }
     private val rowsAdapter by lazy { ArrayObjectAdapter(rowsPresenter) }
 
+    /** ViewModel’ы */
     private val detailsViewModel by viewModel<DetailsViewModel> { argExtra }
-
     private val headerViewModel by viewModel<DetailHeaderViewModel> { argExtra }
-
     private val relatedViewModel by viewModel<DetailRelatedViewModel> { argExtra }
-
     private val recommendsViewModel by viewModel<DetailRecommendsViewModel> { argExtra }
 
-    private fun getViewModel(rowId: Long): ViewModel? = when (rowId) {
+    /**
+     * По rowId возвращаем ViewModel: либо headerViewModel, либо relatedViewModel/recommendsViewModel.
+     */
+    private fun getViewModel(rowId: Long): Any? = when (rowId) {
         DetailsViewModel.RELEASE_ROW_ID -> headerViewModel
         DetailsViewModel.RELATED_ROW_ID -> relatedViewModel
         DetailsViewModel.RECOMMENDS_ROW_ID -> recommendsViewModel
@@ -83,102 +93,109 @@ class DetailFragment : RowsSupportFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        // Привязываем lifecycle (чтобы onResume()/onPause() и др. вызывались)
         viewLifecycleOwner.lifecycle.addObserver(detailsViewModel)
         viewLifecycleOwner.lifecycle.addObserver(headerViewModel)
         viewLifecycleOwner.lifecycle.addObserver(relatedViewModel)
         viewLifecycleOwner.lifecycle.addObserver(recommendsViewModel)
 
+        // Ставим адаптер
         adapter = rowsAdapter
 
+        // Обработка кликов
         setOnItemViewClickedListener { _, item, _, row ->
-            val viewMode: BaseCardsViewModel? =
-                getViewModel((row as ListRow).id) as? BaseCardsViewModel
-            when (item) {
-                is LinkCard -> viewMode?.onLinkCardClick()
-                is LoadingCard -> viewMode?.onLoadingCardClick()
-                is LibriaCard -> viewMode?.onLibriaCardClick(item)
-            }
-        }
-
-        setOnItemViewSelectedListener { _, item, rowViewHolder, row ->
-            if (row is ListRow) {
-                backgroundManager.applyCard(item)
-            } else if (row is LibriaDetailsRow) {
-                applyImage(row.details?.image.orEmpty())
-            }
-            if (rowViewHolder is CustomListRowViewHolder) {
+            val vm = getViewModel((row as Row).id)
+            // Проверяем, является ли vm «BaseCardsViewModel»
+            if (vm is BaseCardsViewModel) {
                 when (item) {
-                    is LibriaCard -> {
-                        rowViewHolder.setDescription(item.title, item.description)
-                    }
-
-                    is LinkCard -> {
-                        rowViewHolder.setDescription(item.title, "")
-                    }
-
-                    is LoadingCard -> {
-                        rowViewHolder.setDescription(item.title, item.description)
-                    }
-
-                    else -> {
-                        rowViewHolder.setDescription("", "")
-                    }
+                    is LinkCard -> vm.onLinkCardClick()
+                    is LoadingCard -> vm.onLoadingCardClick()
+                    is LibriaCard -> vm.onLibriaCardClick(item)
                 }
             }
         }
 
-        val rowMap = mutableMapOf<Long, Row>()
-        subscribeTo(detailsViewModel.rowListData) { rowList ->
-            val rows = rowList.map { rowId ->
-                val row = rowMap[rowId] ?: createRowBy(rowId, rowsAdapter, getViewModel(rowId)!!)
-                rowMap[rowId] = row
-                row
+        // Выбор (focus) элемента
+        setOnItemViewSelectedListener { _, item, rowViewHolder, row ->
+            // Если это ListRow — используем applyCard(...) для фона
+            if (row is ListRow) {
+                backgroundManager.applyCard(item)
             }
-            rowsAdapter.setItems(rows, RowDiffCallback)
+            // Если это LibriaDetailsRow, вызовем applyImage(...) с его постером
+            else if (row is LibriaDetailsRow) {
+                val url = row.details?.image ?: ""
+                applyImage(url)
+            }
+
+            // А ещё, если rowViewHolder — наш CustomListRowViewHolder, выставим description
+            if (rowViewHolder is CustomListRowViewHolder) {
+                when (item) {
+                    is LibriaCard -> rowViewHolder.setDescription(item.title, item.description)
+                    is LinkCard -> rowViewHolder.setDescription(item.title, "")
+                    is LoadingCard -> rowViewHolder.setDescription(item.title, item.description)
+                    else -> rowViewHolder.setDescription("", "")
+                }
+            }
+        }
+
+        // Подписка на список rowId от detailsViewModel
+        val rowMap = mutableMapOf<Long, Row>()
+        subscribeTo(detailsViewModel.rowListData) { rowIds ->
+            // rowIds обычно [1,2,3]
+            val newRows = rowIds.map { rowId ->
+                rowMap.getOrPut(rowId) { createRowBy(rowId) }
+            }
+            rowsAdapter.setItems(newRows, RowDiffCallback)
         }
     }
 
-    private fun createRowBy(
-        rowId: Long,
-        rowsAdapter: ArrayObjectAdapter,
-        viewModel: ViewModel,
-    ): Row = when (rowId) {
-        DetailsViewModel.RELEASE_ROW_ID -> createHeaderRowBy(
-            rowId,
-            rowsAdapter,
-            viewModel as DetailHeaderViewModel
-        )
-
-        else -> createCardsRowBy(rowId, rowsAdapter, viewModel as BaseCardsViewModel)
+    /**
+     * В зависимости от rowId делаем либо «шапку» (LibriaDetailsRow), либо «cards» (ListRow).
+     */
+    private fun createRowBy(rowId: Long): Row {
+        return when (rowId) {
+            DetailsViewModel.RELEASE_ROW_ID -> createHeaderRow(rowId, headerViewModel)
+            DetailsViewModel.RELATED_ROW_ID,
+            DetailsViewModel.RECOMMENDS_ROW_ID ->
+                createCardsRowBy(rowId, rowsAdapter, getViewModel(rowId) as BaseCardsViewModel)
+            else -> {
+                // Фолбэк (пустая строка)
+                ListRow(HeaderItem("Empty"), ArrayObjectAdapter())
+            }
+        }
     }
 
-    private fun createHeaderRowBy(
-        rowId: Long,
-        rowsAdapter: ArrayObjectAdapter,
-        viewModel: DetailHeaderViewModel,
-    ): Row {
+    /**
+     * Для «шапки» (LibriaDetailsRow)
+     */
+    private fun createHeaderRow(rowId: Long, vm: DetailHeaderViewModel): Row {
         val row = LibriaDetailsRow(rowId)
-        subscribeTo(viewModel.releaseData) {
-            val position = rowsAdapter.indexOf(row)
+        subscribeTo(vm.releaseData) {
+            val pos = rowsAdapter.indexOf(row)
             row.details = it
-            rowsAdapter.notifyArrayItemRangeChanged(position, 1)
+            if (pos >= 0) rowsAdapter.notifyArrayItemRangeChanged(pos, 1)
         }
-        subscribeTo(viewModel.progressState) {
-            val position = rowsAdapter.indexOf(row)
+        subscribeTo(vm.progressState) {
+            val pos = rowsAdapter.indexOf(row)
             row.state = it
-            rowsAdapter.notifyArrayItemRangeChanged(position, 1)
+            if (pos >= 0) rowsAdapter.notifyArrayItemRangeChanged(pos, 1)
         }
         return row
     }
 
+    /**
+     * Вызывается, когда фокус на LibriaDetailsRow → нужно обновить фон (по ссылке на картинку).
+     */
     private fun applyImage(image: String) {
-        backgroundManager.applyImage(image, colorSelector = { null }) {
+        backgroundManager.applyImage(
+            image,
+            colorSelector = { null } // Можно возвращать цвет
+        ) { originalColor ->
             val hslColor = FloatArray(3)
-            ColorUtils.colorToHSL(it, hslColor)
+            ColorUtils.colorToHSL(originalColor, hslColor)
             hslColor[1] = (hslColor[1] + 0.05f).coerceAtMost(1.0f)
             hslColor[2] = (hslColor[2] + 0.05f).coerceAtMost(1.0f)
             ColorUtils.HSLToColor(hslColor)
         }
     }
-
 }

--- a/app-tv/src/main/java/ru/radiationx/anilibria/screen/player/BasePlayerFragment.kt
+++ b/app-tv/src/main/java/ru/radiationx/anilibria/screen/player/BasePlayerFragment.kt
@@ -1,11 +1,14 @@
 package ru.radiationx.anilibria.screen.player
 
 import android.annotation.SuppressLint
-import android.net.Uri
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.View
 import android.view.WindowManager
 import android.widget.FrameLayout
+import android.widget.Toast
+import androidx.annotation.OptIn
+import androidx.core.net.toUri
 import androidx.leanback.app.VideoSupportFragment
 import androidx.leanback.app.VideoSupportFragmentGlueHost
 import androidx.leanback.widget.ArrayObjectAdapter
@@ -14,6 +17,8 @@ import androidx.leanback.widget.ListRow
 import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
@@ -38,53 +43,78 @@ open class BasePlayerFragment : VideoSupportFragment() {
         private set
 
     @SuppressLint("RestrictedApi")
-    @UnstableApi
+    @OptIn(UnstableApi::class)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        // 1) Разрешаем Leanback’у автоматически скрывать панель при воспроизведении
+        isControlsOverlayAutoHideEnabled = true
+        // 2) Разрешаем ручное сворачивание (и любые другие события пользователя)
+        isShowOrHideControlsOverlayOnUserInteraction = true
+
+        // Устанавливаем перехватчик клавиш. Он вызовется ПЕРЕД стандартной обработкой Leanback.
+        // Если мы вернём true, событие не пойдёт дальше, и leanback-навигация по кнопкам не сработает.
+        // Поэтому "глотаем" только Play/Pause, а всё остальное возвращаем false.
+        setOnKeyInterceptListener { _, keyCode, event ->
+            if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE) {
+                Log.d("BasePlayerFragment", "KEYCODE_MEDIA_PLAY_PAUSE pressed")
+
+                // Переключаем плеер вручную:
+                if (playerGlue?.isPlaying == true) {
+                    playerGlue?.pause()
+                } else {
+                    playerGlue?.play()
+                }
+
+                // Показываем оверлей (с его автоскрытием).
+                showControlsOverlay(false)
+
+                // Возвращаем true → событие "съедено" этим перехватчиком.
+                true
+            } else {
+                // Для остальных кнопок даём Leanback делать своё дело
+                false
+            }
+        }
+
         requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         initializePlayer()
         initializeRows()
 
+        // Подключаем skip-логику
         skipsPart = PlayerSkipsPart(
             parent = view as FrameLayout,
             skipButtonText = getString(R.string.player_skip),
             coroutineScope = viewLifecycleOwner.lifecycleScope,
             playerSkipsTimer = get<PreferencesHolder>().playerSkipsTimer,
-            onSeek = {
-                player?.seekTo(it)
-            },
+            onSeek = { position -> player?.seekTo(position) },
             onSkipShow = {
+                // Пока skip показан, запрещаем автоскрытие
                 isShowOrHideControlsOverlayOnUserInteraction = false
                 hideControlsOverlay(false)
             },
             onSkipHide = {
+                // Когда skip убрали, снова включаем автоскрытие
                 isShowOrHideControlsOverlayOnUserInteraction = true
             }
         )
 
+        // По ходу воспроизведения обновляем skip
         playerGlue?.playbackListener = object : VideoPlayerGlue.PlaybackListener {
-            @UnstableApi
             override fun onUpdateProgress() {
                 skipsPart?.update(player?.currentPosition ?: 0)
             }
         }
 
+        // "Хак" для случаев, когда при нажатии "ОК" оверлей не прятался
         fadeCompleteListener = object : OnFadeCompleteListener() {
-
             override fun onFadeInComplete() {
                 super.onFadeInComplete()
-                // workaround for hiding controls when user click "enter"
+                // Перезапускаем флаг автоскрытия (иногда помогает, если есть глюки)
                 isControlsOverlayAutoHideEnabled = false
                 isControlsOverlayAutoHideEnabled = true
             }
         }
-    }
-
-    override fun onVideoSizeChanged(videoWidth: Int, videoHeight: Int) {
-        if (videoWidth == 0 || videoHeight == 0) {
-            return
-        }
-        super.onVideoSizeChanged(videoWidth, videoHeight)
     }
 
     override fun onPause() {
@@ -92,12 +122,14 @@ open class BasePlayerFragment : VideoSupportFragment() {
         playerGlue?.pause()
     }
 
+    @OptIn(UnstableApi::class)
     override fun onDestroyView() {
         super.onDestroyView()
         skipsPart = null
         playerGlue?.playbackListener = null
         requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         releasePlayer()
+        playerGlue = null
     }
 
     protected open fun onCompletePlaying() {}
@@ -121,9 +153,7 @@ open class BasePlayerFragment : VideoSupportFragment() {
 
     @UnstableApi
     private fun initializePlayer() {
-        if (player != null) {
-            throw RuntimeException("Player already initialized")
-        }
+        check(player == null) { "Player already initialized" }
 
         val dataSourceProvider = get<PlayerDataSourceProvider>()
         val dataSourceType = dataSourceProvider.get()
@@ -131,36 +161,40 @@ open class BasePlayerFragment : VideoSupportFragment() {
         val mediaSourceFactory = DefaultMediaSourceFactory(requireContext()).apply {
             setDataSourceFactory(dataSourceFactory)
         }
-        val player = ExoPlayer.Builder(requireContext())
+        player = ExoPlayer.Builder(requireContext())
             .setMediaSourceFactory(mediaSourceFactory)
             .setHandleAudioBecomingNoisy(true)
             .build()
-
-        player.addListener(object : Player.Listener {
-
-            override fun onPlaybackStateChanged(playbackState: Int) {
-                super.onPlaybackStateChanged(playbackState)
-                when (playbackState) {
-                    Player.STATE_ENDED -> onCompletePlaying()
-                    Player.STATE_READY -> onPreparePlaying()
-                    Player.STATE_BUFFERING -> {
+            .apply {
+                addListener(object : Player.Listener {
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        super.onPlaybackStateChanged(playbackState)
+                        when (playbackState) {
+                            Player.STATE_ENDED -> onCompletePlaying()
+                            Player.STATE_READY -> onPreparePlaying()
+                            Player.STATE_BUFFERING, Player.STATE_IDLE -> {}
+                        }
                     }
-
-                    Player.STATE_IDLE -> {
+                    override fun onPlayerError(error: PlaybackException) {
+                        super.onPlayerError(error)
+                        Toast.makeText(
+                            requireContext(),
+                            "Ошибка при воспроизведении: ${error.message}",
+                            Toast.LENGTH_LONG
+                        ).show()
                     }
-                }
+                })
             }
-        })
 
+        val playerAdapter = LeanbackPlayerAdapter(requireContext(), player!!, 500)
 
-        val playerAdapter = LeanbackPlayerAdapter(requireContext(), player, 500)
-
-        val playerGlue = VideoPlayerGlue(requireContext(), playerAdapter).apply {
+        playerGlue = VideoPlayerGlue(
+            context = requireContext(),
+            fragment = this,
+            playerAdapter = playerAdapter
+        ).apply {
             host = VideoSupportFragmentGlueHost(this@BasePlayerFragment)
         }
-
-        this.player = player
-        this.playerGlue = playerGlue
     }
 
     private fun releasePlayer() {
@@ -169,7 +203,7 @@ open class BasePlayerFragment : VideoSupportFragment() {
     }
 
     protected fun preparePlayer(url: String) {
-        player?.setMediaItem(MediaItem.fromUri(Uri.parse(url)), false)
+        player?.setMediaItem(MediaItem.fromUri(url.toUri()), false)
         player?.prepare()
     }
 

--- a/app-tv/src/main/java/ru/radiationx/anilibria/screen/player/PlayerSkipsPart.kt
+++ b/app-tv/src/main/java/ru/radiationx/anilibria/screen/player/PlayerSkipsPart.kt
@@ -25,7 +25,7 @@ import ru.radiationx.data.entity.domain.release.PlayerSkips
  * @property playerSkipsTimer включен ли таймер для автопропуска опенинга
  * @property onSeek функция для отлова намерения перемотки
  * @property onSkipShow функция для отлова события показа кнопки пропуска
- * @property onSkipHide функция для отлава события скрытия кнопки пропуска
+ * @property onSkipHide функция для отлова события скрытия кнопки пропуска
  */
 class PlayerSkipsPart(
     private val parent: FrameLayout,
@@ -52,7 +52,7 @@ class PlayerSkipsPart(
     private var playerSkips: PlayerSkips? = null
     private val skippedList = mutableSetOf<PlayerSkips.Skip>()
     private var currentPosition = 0L
-    private var currentSkipShow = false
+    private var isSkipVisible = false
     private var timerJob: Job? = null
 
     init {
@@ -72,21 +72,30 @@ class PlayerSkipsPart(
         skippedList.clear()
     }
 
+    /**
+     * Вызывается периодически (например, playerGlue?.playbackListener?.onUpdateProgress())
+     */
     fun update(position: Long) {
         currentPosition = position
         autoCancel()
         val skip = getCurrentSkip()
         val hasSkip = skip != null
-        binding.apply {
-            if (hasSkip && (!btSkipsSkip.isFocused && !btSkipsCancel.isFocused)) {
-                btSkipsSkip.requestFocus()
-                startTimerIfNeed()
-            }
+
+        // Если раньше skip отображался, а сейчас нет - значит перепрыгнули
+        if (skip == null && isSkipVisible) {
+            isSkipVisible = false
+            onSkipHide.invoke()
+            binding.root.isVisible = false
         }
-        if (hasSkip == currentSkipShow) {
-            return
+
+        // Если skip есть и кнопки не в фокусе — фокусируем по умолчанию на "Пропустить"
+        if (hasSkip && (!binding.btSkipsSkip.isFocused && !binding.btSkipsCancel.isFocused)) {
+            binding.btSkipsSkip.requestFocus()
         }
-        currentSkipShow = hasSkip
+
+        if (hasSkip == isSkipVisible) return
+
+        isSkipVisible = hasSkip
         if (hasSkip) {
             onSkipShow.invoke()
         } else {
@@ -96,12 +105,14 @@ class PlayerSkipsPart(
     }
 
     private fun getCurrentSkip(): PlayerSkips.Skip? {
-        return playerSkips?.opening?.takeIf { checkSkip(it) }
-            ?: playerSkips?.ending?.takeIf { checkSkip(it) }
+        return playerSkips?.opening?.takeIf(::checkSkip)
+            ?: playerSkips?.ending?.takeIf(::checkSkip)
     }
 
     private fun checkSkip(skip: PlayerSkips.Skip): Boolean {
-        return !skippedList.contains(skip) && currentPosition >= skip.start && currentPosition <= skip.end
+        return !skippedList.contains(skip) &&
+               currentPosition >= skip.start &&
+               currentPosition <= skip.end
     }
 
     private fun autoCancel() {
@@ -111,7 +122,6 @@ class PlayerSkipsPart(
         if (opening != null && opening !in skippedList && opening.end < currentPosition) {
             skippedList.add(opening)
         }
-
         if (ending != null && ending !in skippedList && ending.end < currentPosition) {
             skippedList.add(ending)
         }
@@ -134,22 +144,17 @@ class PlayerSkipsPart(
     }
 
     private fun skip() {
-        getCurrentSkip()?.also {
-            onSeek(it.end)
-        }
+        getCurrentSkip()?.also { onSeek(it.end) }
         cancelSkip()
     }
 
     private fun observeSkipTimerState() {
         _timerFlow
             .onEach { remainingTimeSec ->
-                val text = if (remainingTimeSec != null) {
-                    "$skipButtonText ($remainingTimeSec)"
-                } else {
-                    skipButtonText
-                }
+                val text = remainingTimeSec?.let { "$skipButtonText ($it)" } ?: skipButtonText
                 binding.btSkipsSkip.text = text
-            }.launchIn(coroutineScope)
+            }
+            .launchIn(coroutineScope)
     }
 
     private fun startTimerIfNeed() {

--- a/app-tv/src/main/java/ru/radiationx/anilibria/screen/player/VideoPlayerGlue.kt
+++ b/app-tv/src/main/java/ru/radiationx/anilibria/screen/player/VideoPlayerGlue.kt
@@ -18,6 +18,7 @@
 package ru.radiationx.anilibria.screen.player
 
 import android.content.Context
+import androidx.leanback.app.VideoSupportFragment
 import androidx.leanback.media.PlaybackTransportControlGlue
 import androidx.leanback.widget.Action
 import androidx.leanback.widget.ArrayObjectAdapter
@@ -52,6 +53,10 @@ import java.util.concurrent.TimeUnit
 @UnstableApi
 class VideoPlayerGlue(
     context: Context,
+    /**
+     * Ссылка на [VideoSupportFragment], чтобы можно было управлять оверлеем.
+     */
+    private val fragment: VideoSupportFragment,
     playerAdapter: LeanbackPlayerAdapter,
 ) : PlaybackTransportControlGlue<LeanbackPlayerAdapter>(context, playerAdapter) {
 
@@ -79,11 +84,6 @@ class VideoPlayerGlue(
     private val speedAction by lazy { SpeedAction(context) }
     private val episodesAction by lazy { EpisodesAction(context) }
 
-    override fun onUpdateProgress() {
-        super.onUpdateProgress()
-        playbackListener?.onUpdateProgress()
-    }
-
     init {
         isSeekEnabled = true
     }
@@ -91,14 +91,13 @@ class VideoPlayerGlue(
     override fun onCreatePrimaryActions(adapter: ArrayObjectAdapter) {
         super.onCreatePrimaryActions(adapter)
         adapter.add(previousAction)
-        //adapter.add(mRewindAction);
-        //adapter.add(mFastForwardAction);
         adapter.add(nextAction)
     }
 
     override fun onCreateSecondaryActions(adapter: ArrayObjectAdapter) {
         super.onCreateSecondaryActions(adapter)
-        qualityAction.index = 1
+        // По умолчанию иконка качества у нас стоит на HD
+        qualityAction.index = QualityAction.INDEX_HD
         adapter.add(qualityAction)
         adapter.add(speedAction)
         adapter.add(episodesAction)
@@ -107,13 +106,36 @@ class VideoPlayerGlue(
     override fun onActionClicked(action: Action) {
         if (shouldDispatchAction(action)) {
             dispatchAction(action)
-            return
+        } else {
+            super.onActionClicked(action)
         }
-        super.onActionClicked(action)
+    }
+
+    override fun onUpdateProgress() {
+        super.onUpdateProgress()
+        playbackListener?.onUpdateProgress()
+    }
+
+    /**
+     * Вызывается, когда переключаемся между Play/Pause.
+     * Если вы нажимаете аппаратную кнопку Play/Pause и `BasePlayerFragment` «глотает»
+     * это событие, Leanback может не запустить «автоскрытие» оверлея автоматически.
+     *
+     * Чтобы этого не случилось, мы явно перезапускаем показ + автоскрытие.
+     */
+    override fun onPlayStateChanged() {
+        super.onPlayStateChanged()
+        fragment.showControlsOverlay(false)
+        fragment.isControlsOverlayAutoHideEnabled = false
+        fragment.isControlsOverlayAutoHideEnabled = true
     }
 
     private fun shouldDispatchAction(action: Action): Boolean {
-        return action === rewindAction || action === forwardAction || action === qualityAction || action === speedAction || action === episodesAction
+        return action === rewindAction ||
+               action === forwardAction ||
+               action === qualityAction ||
+               action === speedAction ||
+               action === episodesAction
     }
 
     private fun dispatchAction(action: Action) {
@@ -125,21 +147,16 @@ class VideoPlayerGlue(
             action === episodesAction -> actionListener?.onEpisodesClick()
             action is MultiAction -> {
                 action.nextIndex()
-                // Notify adapter of action changes to handle secondary actions, such as, thumbs up/down
-                // and repeat.
-                controlsRow?.also {
-                    notifyActionChanged(
-                        action,
-                        it.secondaryActionsAdapter as ArrayObjectAdapter
-                    )
+                controlsRow?.let { row ->
+                    (row.secondaryActionsAdapter as? ArrayObjectAdapter)?.let { adapter ->
+                        notifyActionChanged(action, adapter)
+                    }
                 }
             }
         }
     }
 
-    private fun notifyActionChanged(
-        action: MultiAction, adapter: ArrayObjectAdapter,
-    ) {
+    private fun notifyActionChanged(action: MultiAction, adapter: ArrayObjectAdapter) {
         val index = adapter.indexOf(action)
         if (index >= 0) {
             adapter.notifyArrayItemRangeChanged(index, 1)
@@ -154,38 +171,37 @@ class VideoPlayerGlue(
         actionListener?.onPrevious()
     }
 
-    /** Skips backwards 10 seconds.  */
+    /** Skips backwards 10 seconds. */
     fun rewind() {
         var newPosition = currentPosition - TEN_SECONDS
-        newPosition = if (newPosition < 0) 0 else newPosition
-        playerAdapter!!.seekTo(newPosition)
+        if (newPosition < 0) newPosition = 0
+        playerAdapter?.seekTo(newPosition)
     }
 
-    /** Skips forward 10 seconds.  */
+    /** Skips forward 10 seconds. */
     fun fastForward() {
         if (duration > -1) {
             var newPosition = currentPosition + TEN_SECONDS
-            newPosition = if (newPosition > duration) duration else newPosition
-            playerAdapter!!.seekTo(newPosition)
+            if (newPosition > duration) newPosition = duration
+            playerAdapter?.seekTo(newPosition)
         }
     }
 
+    /** Установить иконку качества (SD / HD / FULLHD) в панель управления. */
     fun setQuality(quality: PlayerQuality) {
         qualityAction.index = when (quality) {
             PlayerQuality.SD -> QualityAction.INDEX_SD
             PlayerQuality.HD -> QualityAction.INDEX_HD
             PlayerQuality.FULLHD -> QualityAction.INDEX_FHD
         }
-        controlsRow?.also {
-            notifyActionChanged(
-                qualityAction,
-                it.secondaryActionsAdapter as ArrayObjectAdapter
-            )
+        controlsRow?.let { row ->
+            (row.secondaryActionsAdapter as? ArrayObjectAdapter)?.let { adapter ->
+                notifyActionChanged(qualityAction, adapter)
+            }
         }
     }
 
     companion object {
         private val TEN_SECONDS = TimeUnit.SECONDS.toMillis(10)
     }
-
 }

--- a/app-tv/src/main/res/layout/row_detail_release.xml
+++ b/app-tv/src/main/res/layout/row_detail_release.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/rowReleaseRoot"
@@ -30,6 +31,7 @@
         android:orientation="horizontal"
         app:layout_constraintGuide_end="?browsePaddingBottom" />
 
+    <!-- Изображение справа -->
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/rowReleaseImageCard"
         android:layout_width="0dp"
@@ -43,9 +45,11 @@
         app:layout_constraintBottom_toTopOf="@id/rowReleaseActions"
         app:layout_constraintDimensionRatio="260:370"
         app:layout_constraintEnd_toEndOf="@id/guideline_right"
+        app:layout_constraintStart_toEndOf="@id/guideline_left"
         app:layout_constraintTop_toTopOf="parent"
         app:shapeAppearanceOverlay="@style/AppTheme.RoundedImageView" />
 
+    <!-- Заголовок (RU) -->
     <TextView
         android:id="@+id/rowReleaseTitleRu"
         android:layout_width="0dp"
@@ -59,13 +63,13 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Фантазия Гранблю 2" />
 
+    <!-- Заголовок (ENG) -->
     <TextView
         android:id="@+id/rowReleaseTitleEn"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:layout_marginEnd="?browsePaddingEnd"
-        android:ellipsize="end"
         android:maxLines="1"
         android:textColor="@color/dark_textDefault"
         android:textSize="16sp"
@@ -74,22 +78,21 @@
         app:layout_constraintTop_toBottomOf="@id/rowReleaseTitleRu"
         tools:text="Granblue Fantasy The Animation Season 2" />
 
+    <!-- Дополнительное (год, жанр...) -->
     <TextView
         android:id="@+id/rowReleaseExtra"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:layout_marginEnd="16dp"
-        android:ellipsize="end"
         android:maxLines="1"
         android:textColor="@color/dark_textDefault"
         android:textSize="16sp"
+        app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toStartOf="@id/rowReleaseHQMarker"
-        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="@id/guideline_left"
         app:layout_constraintTop_toBottomOf="@id/rowReleaseTitleEn"
-        app:layout_constraintWidth_default="wrap"
         tools:text="2019 год, Экшен, ТВ (12эп.) 12 мин., Выходит по четвергам " />
 
     <androidx.appcompat.widget.AppCompatImageView
@@ -113,12 +116,11 @@
         android:layout_marginEnd="?browsePaddingEnd"
         android:drawablePadding="2dp"
         android:drawableTint="@color/dark_textDefault"
+        android:theme="@style/AppTheme.Material"
         android:textColor="@color/dark_textDefault"
         android:textSize="16sp"
-        android:theme="@style/AppTheme.Material"
         android:visibility="gone"
         app:drawableEndCompat="@drawable/ic_details_favorite"
-        app:drawableTint="@color/dark_textDefault"
         app:layout_constraintBottom_toBottomOf="@id/rowReleaseExtra"
         app:layout_constraintEnd_toStartOf="@id/rowReleaseImageCard"
         app:layout_constraintStart_toEndOf="@id/rowReleaseHQMarker"
@@ -148,11 +150,11 @@
         tools:text="Новая серия каждую субботу."
         tools:visibility="visible" />
 
-
+    <!-- Блок описания (растягивается от rowReleaseAnnounce до rowReleaseActions) -->
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/rowReleaseDescriptionCard"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="?browsePaddingEnd"
         android:layout_marginBottom="16dp"
@@ -162,30 +164,34 @@
         android:focusableInTouchMode="false"
         android:nextFocusDown="@id/rowReleaseActions"
         android:orientation="vertical"
-        app:layout_constrainedHeight="true"
+        app:layout_constraintTop_toBottomOf="@id/rowReleaseAnnounce"
         app:layout_constraintBottom_toTopOf="@id/rowReleaseActions"
-        app:layout_constraintEnd_toStartOf="@id/rowReleaseImageCard"
         app:layout_constraintStart_toStartOf="@id/guideline_left"
-        app:layout_constraintTop_toBottomOf="@id/rowReleaseAnnounce">
+        app:layout_constraintEnd_toStartOf="@id/rowReleaseImageCard">
 
-        <TextView
-            android:id="@+id/rowReleaseDescription"
+        <!-- ScrollView, чтобы текст прокручивался, а не уезжал -->
+        <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:alpha="0.8"
-            android:ellipsize="end"
-            android:lineSpacingMultiplier="1.33"
-            android:maxLines="4"
-            android:textColor="@color/dark_textDefault"
-            android:textSize="14sp"
-            app:layout_constraintEnd_toStartOf="@id/rowReleaseImageCard"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/rowReleaseExtra"
-            tools:text="@tools:sample/lorem/random" />
+            android:layout_height="match_parent"
+            android:layout_margin="8dp"
+            android:scrollbars="vertical"
+            android:fadeScrollbars="false">
+
+            <TextView
+                android:id="@+id/rowReleaseDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:alpha="0.8"
+                android:lineSpacingMultiplier="1.33"
+                android:textColor="@color/dark_textDefault"
+                android:textSize="14sp"
+                tools:text="@tools:sample/lorem/random" />
+
+        </ScrollView>
 
     </androidx.appcompat.widget.LinearLayoutCompat>
 
-
+    <!-- Блок кнопок (play, favorite, etc.) -->
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/rowReleaseActions"
         android:layout_width="wrap_content"
@@ -198,7 +204,6 @@
         app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toBottomOf="@id/guideline_bottom"
         app:layout_constraintEnd_toEndOf="@id/guideline_right"
-        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintStart_toStartOf="@id/guideline_left"
         app:layout_constraintVertical_bias="1">
 
@@ -237,12 +242,12 @@
             android:padding="12dp"
             android:paddingStart="0dp"
             android:paddingEnd="0dp"
-            android:text="Смотреть"
             app:srcCompat="@drawable/ic_more_vert"
             app:tint="@color/text_button_color" />
 
     </androidx.appcompat.widget.LinearLayoutCompat>
 
+    <!-- Остальное: прогресс, стрелка и т.д. -->
     <ProgressBar
         android:id="@+id/rowReleaseUpdateProgress"
         style="?android:progressBarStyleSmall"


### PR DESCRIPTION
## Что изменилось

| Подсистема   | Файл(ы)                                                        | Тип изменения                                                                                       |
|--------------|----------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
| TV‑плеер     | `BasePlayerFragment.kt`, `VideoPlayerGlue.kt`, `PlayerSkipsPart.kt` | Исправлен показ/скрытие оверлея при Play/Pause, синхронизирована логика skip‑intro/outro              |
| Экран релиза | `row_detail_release.xml`, `DetailFragment.kt`                  | Описание обёрнуто в `ScrollView`, убраны ограничения по числу строк                                    |

## Зачем это нужно

1. **Оверлей в плеере**  
   - **Проблема:** аппаратный Play/Pause иногда не скрывал или не показывал оверлей, а при автопропусках возникали мерцающие анимации.  
   - **Решение:**  
     - В `BasePlayerFragment` включён штатный `isControlsOverlayAutoHideEnabled` и добавлен перехват `KEYCODE_MEDIA_PLAY_PAUSE` для явного управления показом/скрытием.  
     - `PlayerSkipsPart` теперь уведомляет фрагмент о показе/скрытии блока пропуска, временно отключая авто‑скрытие, чтобы избежать конфликтов.  
     - В `VideoPlayerGlue` добавлен простой `PlaybackListener` для синхронизации обновлений без изменения публичного API.  
   - **Результат:** плавное исчезновение/появление оверлея, корректное поведение при нажатии на ПДУ и отсутствие «дёрганий» во время skip‑intro/outro.

2. **Прокручиваемое описание релиза**  
   - **Проблема:** длинный текст описания обрезался после 3–4 строк, пользователь не видел полный контент.  
   - **Решение:**  
     - В `row_detail_release.xml` контейнер с описанием обёрнут в `ScrollView` (fillViewport=true), убраны атрибуты `maxLines` и `ellipsize`.  
     - В `DetailFragment` логика установки текста осталась прежней, без дополнительных ограничений.  
   - **Результат:** пользователь может прокручивать и читать весь текст описания привычным способом.
 
исправляет проблемы: https://github.com/anilibria/anilibria-app/issues/39, https://github.com/anilibria/anilibria-app/issues/96