### PR TITLE
fix: restore playback speed after player recreation / восстановление скорости после пересоздания плеера

### DIFF
--- a/media-mobile/src/main/java/ru/radiationx/media/mobile/PlayerProxy.kt
+++ b/media-mobile/src/main/java/ru/radiationx/media/mobile/PlayerProxy.kt
@@ -140,6 +140,7 @@ class PlayerProxy {
     private fun restoreState() {
         player.playWhenReady = commonState.playWhenReady
         player.pauseAtEndOfMediaItems = commonState.pauseAtEndOfMediaItems
+        player.setPlaybackSpeed(commonState.speed)
         player.setMediaItems(mediaItemsState.items, mediaItemsState.index, mediaItemsState.position)
         player.prepare()
     }


### PR DESCRIPTION
## Что изменено / What changed

В `PlayerProxy.restoreState()` сохранённая скорость воспроизведения теперь применяется к новому экземпляру `ExoPlayer`.

## Причина / Root cause

`saveState()` сохранял `playbackParameters.speed` в `commonState.speed`, но `restoreState()` не использовал это значение. После возвращения в приложение плеер поэтому продолжал воспроизведение на скорости 1x, хотя интерфейс показывал выбранную пользователем скорость.

## Результат / Impact

Выбранная скорость воспроизведения сохраняется после сворачивания приложения и пересоздания плеера.

## Проверено / Validation

- `./gradlew :media-mobile:compileDebugKotlin :media-mobile:lintDebug`

## Как проверить вручную / Manual verification

1. Установить скорость воспроизведения 2x.
2. Свернуть приложение.
3. Вернуться в приложение.
4. Убедиться, что воспроизведение продолжается на скорости 2x.

Closes #296
