### PR TITLE
Allow debug builds without private signing keys / Разрешить debug-сборки без приватных ключей подписи

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 Android TV приложение: [RuStore](https://www.rustore.ru/catalog/app/ru.radiationx.anilibria.app.tv) | [Releases](https://github.com/anilibria/anilibria-app/releases?q=tv)
 
+## Сборка для разработки
+
+Debug-сборка не требует приватных ключей подписи:
+
+```shell
+./gradlew :media-mobile:assembleDebug :app-mobile:assembleDebug :app-tv:assembleDebug
+```
+
 # Лицензия #
 Исходный код распостраняется под лицензией GPL v3
 

--- a/app-mobile/build.gradle.kts
+++ b/app-mobile/build.gradle.kts
@@ -1,4 +1,3 @@
-import java.io.FileInputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Properties
@@ -12,6 +11,17 @@ plugins {
 fun getDateTime(): String {
     val df = SimpleDateFormat("dd MMMMM yyyy")
     return "${df.format(Date())} г."
+}
+
+val localProperties = Properties().apply {
+    rootProject.file("local.properties")
+        .takeIf { it.isFile }
+        ?.inputStream()
+        ?.use { load(it) }
+}
+val releaseSigningProperties = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
+val hasReleaseSigningConfig = releaseSigningProperties.all {
+    !localProperties.getProperty(it).isNullOrBlank()
 }
 
 android {
@@ -37,15 +47,14 @@ android {
         buildConfig = true
     }
 
-    val localProperties = Properties().apply {
-        load(FileInputStream(rootProject.file("local.properties")))
-    }
     signingConfigs {
-        create("release") {
-            storeFile = file(localProperties.getProperty("storeFile"))
-            storePassword = localProperties.getProperty("storePassword")
-            keyAlias = localProperties.getProperty("keyAlias")
-            keyPassword = localProperties.getProperty("keyPassword")
+        if (hasReleaseSigningConfig) {
+            create("release") {
+                storeFile = file(localProperties.getProperty("storeFile"))
+                storePassword = localProperties.getProperty("storePassword")
+                keyAlias = localProperties.getProperty("keyAlias")
+                keyPassword = localProperties.getProperty("keyPassword")
+            }
         }
     }
 
@@ -59,7 +68,7 @@ android {
             )
         }
         release {
-            signingConfig = signingConfigs.getByName("release")
+            signingConfigs.findByName("release")?.let { signingConfig = it }
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(
@@ -134,11 +143,7 @@ kotlin {
 }
 
 appmetrica {
-    val localProperties = Properties().apply {
-        load(FileInputStream(rootProject.file("local.properties")))
-    }
-    val propApiKey = localProperties.getProperty("appmetrica_post_api_key", "")
-    setPostApiKey(propApiKey)
+    setPostApiKey(localProperties.getProperty("appmetrica_post_api_key").orEmpty())
 }
 
 dependencies {

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -1,4 +1,3 @@
-import java.io.FileInputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Properties
@@ -11,6 +10,17 @@ plugins {
 fun getDateTime(): String {
     val df = SimpleDateFormat("dd MMMMM yyyy")
     return "${df.format(Date())} г."
+}
+
+val localProperties = Properties().apply {
+    rootProject.file("local.properties")
+        .takeIf { it.isFile }
+        ?.inputStream()
+        ?.use { load(it) }
+}
+val releaseSigningProperties = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
+val hasReleaseSigningConfig = releaseSigningProperties.all {
+    !localProperties.getProperty(it).isNullOrBlank()
 }
 
 android {
@@ -32,21 +42,20 @@ android {
         buildConfig = true
     }
 
-    val localProperties = Properties().apply {
-        load(FileInputStream(rootProject.file("local.properties")))
-    }
     signingConfigs {
-        create("release") {
-            storeFile = file(localProperties.getProperty("storeFile"))
-            storePassword = localProperties.getProperty("storePassword")
-            keyAlias = localProperties.getProperty("keyAlias")
-            keyPassword = localProperties.getProperty("keyPassword")
+        if (hasReleaseSigningConfig) {
+            create("release") {
+                storeFile = file(localProperties.getProperty("storeFile"))
+                storePassword = localProperties.getProperty("storePassword")
+                keyAlias = localProperties.getProperty("keyAlias")
+                keyPassword = localProperties.getProperty("keyPassword")
+            }
         }
     }
 
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("release")
+            signingConfigs.findByName("release")?.let { signingConfig = it }
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
Closes #300

## Summary / Что изменено

- `local.properties` загружается безопасно и только один раз в каждом application-модуле;
- release signing config создаётся только при наличии всех параметров подписи;
- debug-сборки больше не требуют приватных release-секретов;
- `appmetrica_post_api_key` остаётся опциональным;
- в README добавлена команда debug-сборки.

Если signing-параметры отсутствуют, release-варианты остаются неподписанными.

## Root cause / Причина

`app-mobile` и `app-tv` безусловно загружали `local.properties` и создавали release signing config во время конфигурации Gradle. Поэтому даже debug-сборка другого модуля зависела от приватных ключей подписи. `app-mobile` дополнительно загружал тот же файл второй раз для AppMetrica.

## Impact / Результат

Разработчики могут собирать библиотечный модуль, mobile и TV debug-варианты на чистом клоне без приватных signing-параметров.

## Validation / Проверка

Сборка проверена без `local.properties`:

```shell
./gradlew :media-mobile:assembleDebug :app-mobile:assembleDebug :app-tv:assembleDebug
```

```text
BUILD SUCCESSFUL
386 actionable tasks
```